### PR TITLE
Add GitHub Actions workflow for staging deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,48 @@
+name: Staging to digitalocean
+
+on:
+  push:
+    tags:
+    - stage-*
+
+jobs: 
+  build:
+   
+    runs-on: ubuntu-latest
+   
+    steps:
+      - name: Checkout files    
+        uses: actions/checkout@v2
+      - name: Copy Docker file
+        run: cp ${{ github.workspace }}/docker-deploy/Dockerfile ${{ github.workspace }}/Dockerfile
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          repository: jmacboy/pruebagitflow2026
+          tag_with_ref: true
+          tag_with_sha: true
+        
+  deploy:
+    needs: build
+    
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout files    
+        uses: actions/checkout@v2
+        
+      - name: Get tag name
+        uses: olegtarasov/get-tag@v2.1
+        
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+         token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+         
+      - name: Provision Droplet and deploy container
+        run: doctl compute droplet create "$GIT_TAG_NAME" --image docker-20-04 --size s-1vcpu-1gb --region nyc1 --user-data-file deploy.sh --wait
+
+
+    


### PR DESCRIPTION
This workflow automates the staging deployment process to DigitalOcean upon pushing tags that match 'stage-*'. It includes steps for building Docker images and provisioning a droplet.